### PR TITLE
Add BSML dependency to manifest

### DIFF
--- a/SaberHighlight/SaberHighlight/manifest.json
+++ b/SaberHighlight/SaberHighlight/manifest.json
@@ -8,6 +8,7 @@
   "gameVersion": "1.40.5",
   "dependsOn": {
     "BSIPA": "^4.3.5",
-    "SiraUtil": "^3.2.0"
+    "SiraUtil": "^3.2.0",
+    "BSML": "^1.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `BSML` to `dependsOn` in the mod manifest

## Testing
- `dotnet build SaberHighlight/SaberHighlight/SaberHighlight.csproj -nologo` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68421a01ad588332ba4303a5b30aa094